### PR TITLE
Arreglada la carga de mapas Integer.

### DIFF
--- a/Codigo/frmConvert.frm
+++ b/Codigo/frmConvert.frm
@@ -179,7 +179,7 @@ Private Automatico As Boolean
 
 Private Sub Check1_Click()
 
-    If Check1.value = False Then
+    If Check1.Value = False Then
         Label6.Visible = False
         Label7.Visible = False
         Label8.Visible = False
@@ -202,7 +202,7 @@ Private Sub Command1_Click()
 
     If Automatico = False Then
         Call modMapIO.NuevoMapa
-        Call MapaV2_Cargar(App.Path & "\Conversor\Mapas Integer\Mapa" & Text1.Text & ".map",)
+        Call MapaV2_Cargar(App.Path & "\Conversor\Mapas Integer\Mapa" & Text1.Text & ".map", True)
         Call MapaV2_Guardar(App.Path & "\Conversor\Mapas Long\Mapa" & Text1.Text & ".map")
         
         Info.Caption = "Conversion realizada correctamente!"
@@ -216,6 +216,9 @@ Private Sub Command1_Click()
                 
                 'Abrimos el mapa integer.
                 Call MapaV2_Cargar(App.Path & "\Conversor\Mapas Integer\Mapa" & i & ".map", True)
+                
+                'Lo metemos forzosamente a False asi el sub lo guarda como Long.
+                MapaCargado_Integer = False
                 
                 Call MapaV2_Guardar(App.Path & "\Conversor\Mapas Long\Mapa" & i & ".map")
             

--- a/Codigo/frmConvert.frm
+++ b/Codigo/frmConvert.frm
@@ -202,7 +202,7 @@ Private Sub Command1_Click()
 
     If Automatico = False Then
         Call modMapIO.NuevoMapa
-        Call MapaInteger_Cargar(App.Path & "\Conversor\Mapas Integer\Mapa" & Text1.Text & ".map")
+        Call MapaV2_Cargar(App.Path & "\Conversor\Mapas Integer\Mapa" & Text1.Text & ".map",)
         Call MapaV2_Guardar(App.Path & "\Conversor\Mapas Long\Mapa" & Text1.Text & ".map")
         
         Info.Caption = "Conversion realizada correctamente!"
@@ -211,8 +211,12 @@ Private Sub Command1_Click()
         For i = Text1.Text To Text2.Text
 
             If FileExist(App.Path & "\Conversor\Mapas Integer\Mapa" & i & ".map", vbNormal) = True Then
+                
                 Call modMapIO.NuevoMapa
-                Call MapaInteger_Cargar(App.Path & "\Conversor\Mapas Integer\Mapa" & i & ".map")
+                
+                'Abrimos el mapa integer.
+                Call MapaV2_Cargar(App.Path & "\Conversor\Mapas Integer\Mapa" & i & ".map", True)
+                
                 Call MapaV2_Guardar(App.Path & "\Conversor\Mapas Long\Mapa" & i & ".map")
             
                 Info.Caption = "Mapa" & i & " convertido correctamente!"
@@ -230,16 +234,19 @@ Private Sub Command2_Click()
     Dim i As Integer
 
     If Automatico = False Then
+        
         Call modMapIO.NuevoMapa
-        Call MapaV2_Cargar(App.Path & "\Conversor\Mapas Long\Mapa" & Text1.Text & ".map")
+        Call modMapIO.MapaV2_Cargar(App.Path & "\Conversor\Mapas Long\Mapa" & Text1.Text & ".map", True)
         Call Save_CSM(App.Path & "\Conversor\Mapas CSM\Mapa" & Text1.Text & ".csm")
         
         Info.Caption = "Conversion realizada correctamente!"
+    
     Else
 
         For i = Text1.Text To Text2.Text
             
             If FileExist(App.Path & "\Conversor\Mapas Long\Mapa" & i & ".map", vbNormal) = True Then
+                
                 Call modMapIO.NuevoMapa
                 Call MapaV2_Cargar(App.Path & "\Conversor\Mapas Long\Mapa" & i & ".map")
                 Call Save_CSM(App.Path & "\Conversor\Mapas CSM\Mapa" & i & ".csm")

--- a/Codigo/frmMain.frm
+++ b/Codigo/frmMain.frm
@@ -1,6 +1,6 @@
 VERSION 5.00
-Object = "{F9043C88-F6F2-101A-A3C9-08002B2F49FB}#1.2#0"; "COMDLG32.OCX"
-Object = "{3B7C8863-D78F-101B-B9B5-04021C009402}#1.2#0"; "Richtx32.ocx"
+Object = "{F9043C88-F6F2-101A-A3C9-08002B2F49FB}#1.2#0"; "ijl11.dll"
+Object = "{3B7C8863-D78F-101B-B9B5-04021C009402}#1.2#0"; "RICHTX32.ocx"
 Begin VB.Form frmMain 
    Appearance      =   0  'Flat
    BackColor       =   &H00FFFFFF&
@@ -2630,6 +2630,7 @@ Begin VB.Form frmMain
       _ExtentY        =   2037
       _Version        =   393217
       BackColor       =   16777215
+      Enabled         =   -1  'True
       ReadOnly        =   -1  'True
       ScrollBars      =   2
       DisableNoScroll =   -1  'True
@@ -3635,7 +3636,7 @@ Private Sub PonerAlAzar(ByVal n As Integer, T As Byte)
                 If MapData(X, Y).OBJInfo.objindex = 0 Then
                     i = i - 1
 
-                    If cInsertarBloqueo.Value = True Then
+                    If cInsertarBloqueo.value = True Then
                         MapData(X, Y).blocked = 1
                     Else
                         MapData(X, Y).blocked = 0
@@ -3838,7 +3839,7 @@ Private Sub cInsertarFunc_Click(index As Integer)
     'Author: ^[GS]^
     'Last modified: 20/05/06
     '*************************************************
-    If cInsertarFunc(index).Value = True Then
+    If cInsertarFunc(index).value = True Then
         cQuitarFunc(index).Enabled = False
         cAgregarFuncalAzar(index).Enabled = False
 
@@ -3857,7 +3858,7 @@ End Sub
 
 Private Sub cInsertarLuz_Click()
 
-    If cInsertarLuz.Value Then
+    If cInsertarLuz.value Then
         cQuitarLuz.Enabled = False
     Else
         cQuitarLuz.Enabled = True
@@ -3872,7 +3873,7 @@ Private Sub cInsertarTrans_Click()
     'Author: ^[GS]^
     'Last modified: 22/05/06
     '*************************************************
-    If cInsertarTrans.Value = True Then
+    If cInsertarTrans.value = True Then
         cQuitarTrans.Enabled = False
         Call modPaneles.EstSelectPanel(1, True)
     Else
@@ -3889,7 +3890,7 @@ Private Sub cInsertarTrigger_Click()
     'Author: ^[GS]^
     'Last modified: 20/05/06
     '*************************************************
-    If cInsertarTrigger.Value = True Then
+    If cInsertarTrigger.value = True Then
         cQuitarTrigger.Enabled = False
         Call modPaneles.EstSelectPanel(6, True)
     Else
@@ -3902,7 +3903,7 @@ End Sub
 
 Private Sub cmdAdd_Click()
 
-    If cmdAdd.Value = True Then
+    If cmdAdd.value = True Then
         cmdDel.Enabled = False
         Call modPaneles.EstSelectPanel(8, True)
     Else
@@ -3915,7 +3916,7 @@ End Sub
 
 Private Sub cmdDel_Click()
 
-    If cmdDel.Value = True Then
+    If cmdDel.value = True Then
         lstParticle.Enabled = False
         cmdAdd.Enabled = False
         Call modPaneles.EstSelectPanel(8, True)
@@ -4013,7 +4014,7 @@ Private Sub cQuitarLuz_Click()
     '*************************************************
     'Author: Lorwik
     '*************************************************
-    If cQuitarLuz.Value Then
+    If cQuitarLuz.value Then
         cInsertarLuz.Enabled = False
     Else
         cInsertarLuz.Enabled = True
@@ -4027,7 +4028,7 @@ Private Sub cUnionManual_Click()
     'Author: ^[GS]^
     'Last modified: 20/05/06
     '*************************************************
-    cInsertarTrans.Value = (cUnionManual.Value = True)
+    cInsertarTrans.value = (cUnionManual.value = True)
     Call cInsertarTrans_Click
 
 End Sub
@@ -4037,7 +4038,7 @@ Private Sub cverBloqueos_Click()
     'Author: ^[GS]^
     'Last modified: 20/05/06
     '*************************************************
-    mnuVerBloqueos.Checked = cVerBloqueos.Value
+    mnuVerBloqueos.Checked = cVerBloqueos.value
 
 End Sub
 
@@ -4046,7 +4047,7 @@ Private Sub cverTriggers_Click()
     'Author: ^[GS]^
     'Last modified: 20/05/06
     '*************************************************
-    mnuVerTriggers.Checked = cVerTriggers.Value
+    mnuVerTriggers.Checked = cVerTriggers.value
 
 End Sub
 
@@ -4137,7 +4138,7 @@ Private Sub cInsertarBloqueo_Click()
     '*************************************************
     cInsertarBloqueo.Tag = vbNullString
 
-    If cInsertarBloqueo.Value = True Then
+    If cInsertarBloqueo.value = True Then
         cQuitarBloqueo.Enabled = False
         Call modPaneles.EstSelectPanel(2, True)
     Else
@@ -4155,7 +4156,7 @@ Private Sub cQuitarBloqueo_Click()
     '*************************************************
     cInsertarBloqueo.Tag = vbNullString
 
-    If cQuitarBloqueo.Value = True Then
+    If cQuitarBloqueo.value = True Then
         cInsertarBloqueo.Enabled = False
         Call modPaneles.EstSelectPanel(2, True)
     Else
@@ -4172,7 +4173,7 @@ Private Sub cQuitarEnEstaCapa_Click()
     'Author: ^[GS]^
     'Last modified: 20/05/06
     '*************************************************
-    If cQuitarEnEstaCapa.Value = True Then
+    If cQuitarEnEstaCapa.value = True Then
         lListado(0).Enabled = False
         cFiltro(0).Enabled = False
         cGrh.Enabled = False
@@ -4197,7 +4198,7 @@ Private Sub cQuitarEnTodasLasCapas_Click()
     'Author: ^[GS]^
     'Last modified: 20/05/06
     '*************************************************
-    If cQuitarEnTodasLasCapas.Value = True Then
+    If cQuitarEnTodasLasCapas.value = True Then
         cCapas.Enabled = False
         lListado(0).Enabled = False
         cFiltro(0).Enabled = False
@@ -4224,7 +4225,7 @@ Private Sub cQuitarFunc_Click(index As Integer)
     'Author: ^[GS]^
     'Last modified: 20/05/06
     '*************************************************
-    If cQuitarFunc(index).Value = True Then
+    If cQuitarFunc(index).value = True Then
         cInsertarFunc(index).Enabled = False
         cAgregarFuncalAzar(index).Enabled = False
         cCantFunc(index).Enabled = False
@@ -4251,7 +4252,7 @@ Private Sub cQuitarTrans_Click()
     'Author: ^[GS]^
     'Last modified: 20/05/06
     '*************************************************
-    If cQuitarTrans.Value = True Then
+    If cQuitarTrans.value = True Then
         cInsertarTransOBJ.Enabled = False
         cInsertarTrans.Enabled = False
         cUnionManual.Enabled = False
@@ -4282,7 +4283,7 @@ Private Sub cQuitarTrigger_Click()
     'Author: ^[GS]^
     'Last modified: 20/05/06
     '*************************************************
-    If cQuitarTrigger.Value = True Then
+    If cQuitarTrigger.value = True Then
         lListado(4).Enabled = False
         cInsertarTrigger.Enabled = False
         Call modPaneles.EstSelectPanel(6, True)
@@ -4301,7 +4302,7 @@ Private Sub cSeleccionarSuperficie_Click()
     'Author: ^[GS]^
     'Last modified: 20/05/06
     '*************************************************
-    If cSeleccionarSuperficie.Value = True Then
+    If cSeleccionarSuperficie.value = True Then
         cQuitarEnTodasLasCapas.Enabled = False
         cQuitarEnEstaCapa.Enabled = False
         Call modPaneles.EstSelectPanel(0, True)
@@ -4363,30 +4364,30 @@ Private Sub Form_KeyPress(KeyAscii As Integer)
     Select Case UCase(Chr(KeyAscii))
 
         Case "S" ' Activa/Desactiva Insertar Superficie
-            cSeleccionarSuperficie.Value = (cSeleccionarSuperficie.Value = False)
+            cSeleccionarSuperficie.value = (cSeleccionarSuperficie.value = False)
             Call cSeleccionarSuperficie_Click
 
         Case "T" ' Activa/Desactiva Insertar Translados
-            cInsertarTrans.Value = (cInsertarTrans.Value = False)
+            cInsertarTrans.value = (cInsertarTrans.value = False)
             Call cInsertarTrans_Click
 
         Case "B" ' Activa/Desactiva Insertar Bloqueos
-            cInsertarBloqueo.Value = (cInsertarBloqueo.Value = False)
+            cInsertarBloqueo.value = (cInsertarBloqueo.value = False)
             Call cInsertarBloqueo_Click
 
         Case "N" ' Activa/Desactiva Insertar NPCs
-            cInsertarFunc(0).Value = (cInsertarFunc(0).Value = False)
+            cInsertarFunc(0).value = (cInsertarFunc(0).value = False)
             Call cInsertarFunc_Click(0)
 
             ' Case "H" ' Activa/Desactiva Insertar NPCs Hostiles
             '     cInsertarFunc(1).value = (cInsertarFunc(1).value = False)
             '     Call cInsertarFunc_Click(1)
         Case "O" ' Activa/Desactiva Insertar Objetos
-            cInsertarFunc(2).Value = (cInsertarFunc(2).Value = False)
+            cInsertarFunc(2).value = (cInsertarFunc(2).value = False)
             Call cInsertarFunc_Click(2)
 
         Case "G" ' Activa/Desactiva Insertar Triggers
-            cInsertarTrigger.Value = (cInsertarTrigger.Value = False)
+            cInsertarTrigger.value = (cInsertarTrigger.value = False)
             Call cInsertarTrigger_Click
 
         Case "Q" ' Quitar Funciones
@@ -4435,13 +4436,13 @@ Private Sub lListado_Click(index As Integer)
                 End If
 
                 If SupData(ReadField(2, lListado(index).Text, Asc("#"))).Block = True Then
-                    If LenB(cInsertarBloqueo.Tag) = 0 Then cInsertarBloqueo.Tag = IIf(cInsertarBloqueo.Value = True, 1, 0)
-                    cInsertarBloqueo.Value = True
+                    If LenB(cInsertarBloqueo.Tag) = 0 Then cInsertarBloqueo.Tag = IIf(cInsertarBloqueo.value = True, 1, 0)
+                    cInsertarBloqueo.value = True
                     Call cInsertarBloqueo_Click
                 Else
 
                     If LenB(cInsertarBloqueo.Tag) <> 0 Then
-                        cInsertarBloqueo.Value = IIf(Val(cInsertarBloqueo.Tag) = 1, True, False)
+                        cInsertarBloqueo.value = IIf(Val(cInsertarBloqueo.Tag) = 1, True, False)
                         cInsertarBloqueo.Tag = vbNullString
                         Call cInsertarBloqueo_Click
 
@@ -4572,26 +4573,26 @@ Private Sub Magic_Click()
     
     If LenB(Path) = 0 Then Exit Sub
     
-    Dim Files() As String, File As String
+    Dim Files() As String, file As String
     
-    File = Dir$(Path & "\*.MAP")
+    file = Dir$(Path & "\*.MAP")
     
     Dim Iterator As Integer
     
-    Do While File <> vbNullString
+    Do While file <> vbNullString
         ReDim Preserve Files(Iterator) As String
-        Files(Iterator) = File
+        Files(Iterator) = file
         Iterator = Iterator + 1
-        File = Dir
+        file = Dir
     Loop
     
     Dim Norte As Integer, Sur As Integer, Este As Integer, Oeste As Integer
 
     For Iterator = 0 To UBound(Files)
-        File = Path & "\" & Files(Iterator)
+        file = Path & "\" & Files(Iterator)
     
         Call modMapIO.NuevoMapa
-        Call modMapIO.MapaV2_Cargar(File)
+        Call modMapIO.MapaV2_Cargar(file)
     
         Norte = 0
         Sur = 0
@@ -4606,7 +4607,7 @@ Private Sub Magic_Click()
         
         Call BloquearBordes
         
-        Call modMapIO.MapaV2_Guardar(File, False)
+        Call modMapIO.MapaV2_Guardar(file, False)
     
     Next
         
@@ -4806,7 +4807,6 @@ Private Sub MapPest_Click(index As Integer)
     '*************************************************
     Dim formato As String
 
-    
     Select Case frmMain.Dialog.FilterIndex
     
         Case 0
@@ -4820,7 +4820,7 @@ Private Sub MapPest_Click(index As Integer)
     If (index + NumMap_Save - 4) <> NumMap_Save Then
         Dialog.CancelError = True
 
-        On Error GoTo errhandler
+        On Error GoTo ErrHandler
 
         Dialog.FileName = PATH_Save & NameMap_Save & (index + NumMap_Save - 7) & formato
 
@@ -4842,7 +4842,7 @@ Private Sub MapPest_Click(index As Integer)
                 Call modMapIO.Cargar_CSM(Dialog.FileName)
                 
             Case 1
-                Call modMapIO.MapaV2_Cargar(Dialog.FileName)
+                Call modMapIO.MapaV2_Cargar(Dialog.FileName, MapaCargado_Integer)
             
         End Select
         
@@ -4852,7 +4852,7 @@ Private Sub MapPest_Click(index As Integer)
     
         Exit Sub
     
-errhandler:
+ErrHandler:
         Call MsgBox(Err.Description)
 
 End Sub
@@ -4909,7 +4909,7 @@ Private Sub AbrirMapa(ByVal Selector As Byte)
     '*************************************************
     Dialog.CancelError = True
 
-    On Error GoTo errhandler
+    On Error GoTo ErrHandler
 
     Call DeseaGuardarMapa(Dialog.FileName)
 
@@ -4930,10 +4930,10 @@ Private Sub AbrirMapa(ByVal Selector As Byte)
             Select Case Selector
             
                 Case 1
-                    Call modMapIO.MapaV2_Cargar(Dialog.FileName)
+                    Call modMapIO.MapaV2_Cargar(Dialog.FileName, False)
                     
                 Case 2
-                    Call modMapIO.MapaInteger_Cargar(Dialog.FileName)
+                    Call modMapIO.MapaV2_Cargar(Dialog.FileName, True)
                     
             End Select
             
@@ -4948,7 +4948,7 @@ Private Sub AbrirMapa(ByVal Selector As Byte)
     
     EngineRun = True
 
-errhandler:
+ErrHandler:
 
 End Sub
 
@@ -5080,7 +5080,7 @@ Private Sub mnuBloquear_Click()
     For i = 0 To 6
 
         If i <> 2 Then
-            frmMain.SelectPanel(i).Value = False
+            frmMain.SelectPanel(i).value = False
             Call VerFuncion(i, False)
 
         End If
@@ -5305,7 +5305,7 @@ Private Sub mnuNPCs_Click()
     For i = 0 To 6
 
         If i <> 3 Then
-            frmMain.SelectPanel(i).Value = False
+            frmMain.SelectPanel(i).value = False
             Call VerFuncion(i, False)
 
         End If
@@ -5371,7 +5371,7 @@ Private Sub mnuObjetos_Click()
     For i = 0 To 6
 
         If i <> 5 Then
-            frmMain.SelectPanel(i).Value = False
+            frmMain.SelectPanel(i).value = False
             Call VerFuncion(i, False)
 
         End If
@@ -5479,43 +5479,43 @@ Private Sub mnuQuitarFunciones_Click()
     '*************************************************
     
     ' Superficies
-    cSeleccionarSuperficie.Value = False
+    cSeleccionarSuperficie.value = False
     Call cSeleccionarSuperficie_Click
-    cQuitarEnEstaCapa.Value = False
+    cQuitarEnEstaCapa.value = False
     Call cQuitarEnEstaCapa_Click
-    cQuitarEnTodasLasCapas.Value = False
+    cQuitarEnTodasLasCapas.value = False
     Call cQuitarEnTodasLasCapas_Click
     
     ' Translados
-    cQuitarTrans.Value = False
+    cQuitarTrans.value = False
     Call cQuitarTrans_Click
-    cInsertarTrans.Value = False
+    cInsertarTrans.value = False
     Call cInsertarTrans_Click
     
     ' Bloqueos
-    cQuitarBloqueo.Value = False
+    cQuitarBloqueo.value = False
     Call cQuitarBloqueo_Click
-    cInsertarBloqueo.Value = False
+    cInsertarBloqueo.value = False
     Call cInsertarBloqueo_Click
     
     ' Otras funciones
-    cInsertarFunc(0).Value = False
+    cInsertarFunc(0).value = False
     Call cInsertarFunc_Click(0)
-    cInsertarFunc(1).Value = False
+    cInsertarFunc(1).value = False
     Call cInsertarFunc_Click(1)
-    cInsertarFunc(2).Value = False
+    cInsertarFunc(2).value = False
     Call cInsertarFunc_Click(2)
-    cQuitarFunc(0).Value = False
+    cQuitarFunc(0).value = False
     Call cQuitarFunc_Click(0)
-    cQuitarFunc(1).Value = False
+    cQuitarFunc(1).value = False
     Call cQuitarFunc_Click(1)
-    cQuitarFunc(2).Value = False
+    cQuitarFunc(2).value = False
     Call cQuitarFunc_Click(2)
     
     ' Triggers
-    cInsertarTrigger.Value = False
+    cInsertarTrigger.value = False
     Call cInsertarTrigger_Click
-    cQuitarTrigger.Value = False
+    cQuitarTrigger.value = False
     Call cQuitarTrigger_Click
 
 End Sub
@@ -5602,7 +5602,7 @@ Private Sub mnuReAbrirMapa_Click()
     'Author: ^[GS]^
     'Last modified: 20/05/06
     '*************************************************
-    On Error GoTo errhandler
+    On Error GoTo ErrHandler
 
     If FileExist(Dialog.FileName, vbArchive) = False Then Exit Sub
     
@@ -5634,7 +5634,7 @@ Private Sub mnuReAbrirMapa_Click()
     
     Exit Sub
     
-errhandler:
+ErrHandler:
 
 End Sub
 
@@ -5680,7 +5680,7 @@ Private Sub mnuSuperficie_Click()
     For i = 0 To 6
 
         If i <> 0 Then
-            frmMain.SelectPanel(i).Value = False
+            frmMain.SelectPanel(i).value = False
             Call VerFuncion(i, False)
 
         End If
@@ -5702,7 +5702,7 @@ Private Sub mnuTranslados_Click()
     For i = 0 To 6
 
         If i <> 1 Then
-            frmMain.SelectPanel(i).Value = False
+            frmMain.SelectPanel(i).value = False
             Call VerFuncion(i, False)
 
         End If
@@ -5724,7 +5724,7 @@ Private Sub mnuTriggers_Click()
     For i = 0 To 6
 
         If i <> 6 Then
-            frmMain.SelectPanel(i).Value = False
+            frmMain.SelectPanel(i).value = False
             Call VerFuncion(i, False)
 
         End If
@@ -5758,8 +5758,8 @@ Private Sub mnuVerBloqueos_Click()
     'Author: ^[GS]^
     'Last modified: 20/05/06
     '*************************************************
-    cVerBloqueos.Value = (cVerBloqueos.Value = False)
-    mnuVerBloqueos.Checked = cVerBloqueos.Value
+    cVerBloqueos.value = (cVerBloqueos.value = False)
+    mnuVerBloqueos.Checked = cVerBloqueos.value
 
 End Sub
 
@@ -5837,8 +5837,8 @@ Private Sub mnuVerTriggers_Click()
     'Author: ^[GS]^
     'Last modified: 20/05/06
     '*************************************************
-    cVerTriggers.Value = (cVerTriggers.Value = False)
-    mnuVerTriggers.Checked = cVerTriggers.Value
+    cVerTriggers.value = (cVerTriggers.value = False)
+    mnuVerTriggers.Checked = cVerTriggers.value
 
 End Sub
 
@@ -5991,7 +5991,7 @@ Private Sub SelectPanel_Click(index As Integer)
     For i = 0 To 9
 
         If i <> index Then
-            SelectPanel(i).Value = False
+            SelectPanel(i).value = False
             Call VerFuncion(i, False)
 
         End If
@@ -5999,7 +5999,7 @@ Private Sub SelectPanel_Click(index As Integer)
     Next
 
     If mnuAutoQuitarFunciones.Checked = True Then Call mnuQuitarFunciones_Click
-    Call VerFuncion(index, SelectPanel(index).Value)
+    Call VerFuncion(index, SelectPanel(index).value)
 
 End Sub
 

--- a/Codigo/modMapIO.bas
+++ b/Codigo/modMapIO.bas
@@ -119,6 +119,8 @@ Private MapDat    As tMapDat
 
 Private MapTitulo As String     ' GS > Almacena el titulo del mapa para el .dat
 
+Public MapaCargado_Integer  As Boolean
+
 ''
 ' Obtener el tamaño de un archivo
 '
@@ -157,7 +159,7 @@ End Function
 ' @param FileType Especifica el tipo de archivo/directorio
 ' @return   Nos devuelve verdadero o falso
 
-Public Function FileExist(ByVal File As String, _
+Public Function FileExist(ByVal file As String, _
                           ByVal FileType As VbFileAttribute) As Boolean
 
     '*************************************************
@@ -165,7 +167,7 @@ Public Function FileExist(ByVal File As String, _
     'Last modified: 26/05/06
     '*************************************************
     
-    If LenB(Dir$(File, FileType)) = 0 Then
+    If LenB(Dir$(file, FileType)) = 0 Then
         FileExist = False
     Else
         FileExist = True
@@ -510,7 +512,7 @@ End Sub
 '
 ' @param Map Especifica el Path del mapa
 
-Public Sub MapaV2_Cargar(ByVal Map As String)
+Public Sub MapaV2_Cargar(ByVal Map As String, Optional ByVal EsInteger As Boolean = False)
     '*************************************************
     'Author: ^[GS]^
     'Last modified: 20/05/06
@@ -534,6 +536,10 @@ Public Sub MapaV2_Cargar(ByVal Map As String)
     'Change mouse icon
     frmMain.MousePointer = 11
        
+    'Con esto, le digo al WE que estamos usando mapas de tipo integer,
+    'lo uso mas que nada para que no crashee cargar los mapas siguientes en las Pestañas.
+    MapaCargado_Integer = EsInteger
+    
     'Open files
     FreeFileMap = FreeFile
     Open Map For Binary As FreeFileMap
@@ -571,30 +577,61 @@ Public Sub MapaV2_Cargar(ByVal Map As String)
                 .blocked = (ByFlags And 1)
             
                 'Layer 1
-                Get FreeFileMap, , .Graphic(1).GrhIndex
-                Call InitGrh(.Graphic(1), .Graphic(1).GrhIndex)
+                If EsInteger Then
+                    Get FreeFileMap, , .Graphic(1).GrhIndexIntg
+                    Call InitGrh(.Graphic(1), .Graphic(1).GrhIndexIntg)
+                Else
+                    Get FreeFileMap, , .Graphic(1).GrhIndex
+                    Call InitGrh(.Graphic(1), .Graphic(1).GrhIndex)
+                End If
             
                 'Layer 2 used?
                 If ByFlags And 2 Then
-                    Get FreeFileMap, , .Graphic(2).GrhIndex
-                    Call InitGrh(.Graphic(2), .Graphic(2).GrhIndex)
+                    
+                    If EsInteger Then
+                        Get FreeFileMap, , .Graphic(2).GrhIndexIntg
+                        Call InitGrh(.Graphic(2), .Graphic(2).GrhIndexIntg)
+                    Else
+                        Get FreeFileMap, , .Graphic(2).GrhIndex
+                        Call InitGrh(.Graphic(2), .Graphic(2).GrhIndex)
+                    End If
+ 
                 Else
+                
                     .Graphic(2).GrhIndex = 0
+                    
                 End If
                 
                 'Layer 3 used?
                 If ByFlags And 4 Then
-                    Get FreeFileMap, , .Graphic(3).GrhIndex
-                    Call InitGrh(.Graphic(3), .Graphic(3).GrhIndex)
+                    
+                    If EsInteger Then
+                        Get FreeFileMap, , .Graphic(3).GrhIndexIntg
+                        Call InitGrh(.Graphic(3), .Graphic(3).GrhIndexIntg)
+                    Else
+                        Get FreeFileMap, , .Graphic(3).GrhIndex
+                        Call InitGrh(.Graphic(3), .Graphic(3).GrhIndex)
+                    End If
+
                 Else
+                
                     .Graphic(3).GrhIndex = 0
+                    
                 End If
                 
                 'Layer 4 used?
                 If ByFlags And 8 Then
-                    Get FreeFileMap, , .Graphic(4).GrhIndex
-                    Call InitGrh(.Graphic(4), .Graphic(4).GrhIndex)
+                    
+                    If EsInteger Then
+                        Get FreeFileMap, , .Graphic(4).GrhIndexIntg
+                        Call InitGrh(.Graphic(3), .Graphic(3).GrhIndexIntg)
+                    Else
+                        Get FreeFileMap, , .Graphic(4).GrhIndex
+                        Call InitGrh(.Graphic(4), .Graphic(4).GrhIndex)
+                    End If
+
                 Else
+                    
                     .Graphic(4).GrhIndex = 0
 
                 End If
@@ -667,26 +704,35 @@ Public Sub MapaV2_Cargar(ByVal Map As String)
     
     Call Pestañas(Map, ".map")
     
-    'Call ActualizaMinimap ' Radar
-    
     Map = Left$(Map, Len(Map) - 4) & ".dat"
     
     Call MapInfo_Cargar(Map)
     
-    frmMain.lblMapVersion.Caption = MapInfo.MapVersion
+    With frmMain
     
-    'Set changed flag
-    MapInfo.Changed = 0
+        frmMain.lblMapVersion.Caption = MapInfo.MapVersion
     
-    ' Vacia el Deshacer
-    Call modEdicion.Deshacer_Clear
+        ' Avisamos que estamos trabajando con un mapa de tipo integer.
+        If EsInteger Then
+            .Caption = App.Title & " - Mapa Integer"
+        Else
+            .Caption = App.Title & " - Mapa Long"
+        End If
+        
+        'Set changed flag
+        MapInfo.Changed = 0
+        
+        ' Vacia el Deshacer
+        Call modEdicion.Deshacer_Clear
+        
+        'Change mouse icon
+        .MousePointer = 0
+        
+        CurMap = ReturnNumberFromString(Map)
+        
+        .Minimap.Picture = LoadPicture(DirMinimapas & CStr(CurMap) & ".bmp")
     
-    'Change mouse icon
-    frmMain.MousePointer = 0
-    
-    CurMap = ReturnNumberFromString(Map)
-    
-    frmMain.Minimap.Picture = LoadPicture(DirMinimapas & CStr(CurMap) & ".bmp")
+    End With
     
     MapaCargado = True
 
@@ -825,12 +871,12 @@ Public Sub MapInfo_Actualizar()
         .txtMapZona.Text = MapInfo.Zona
         .txtMapRestringir.Text = MapInfo.Restringir
         '.chkMapBackup.value = MapInfo.BackUp
-        .chkMapMagiaSinEfecto.Value = MapInfo.MagiaSinEfecto
+        .chkMapMagiaSinEfecto.value = MapInfo.MagiaSinEfecto
         '.chkMapInviSinEfecto.value = MapInfo.InviSinEfecto
         '.ChkMapNpc.value = MapInfo.SePuedeDomar
-        .chkMapResuSinEfecto.Value = MapInfo.ResuSinEfecto
-        .chkMapNoEncriptarMP.Value = MapInfo.NoEncriptarMP
-        .chkMapPK.Value = IIf(MapInfo.PK = True, 1, 0)
+        .chkMapResuSinEfecto.value = MapInfo.ResuSinEfecto
+        .chkMapNoEncriptarMP.value = MapInfo.NoEncriptarMP
+        .chkMapPK.value = IIf(MapInfo.PK = True, 1, 0)
         .txtMapVersion = MapInfo.MapVersion
         frmMain.lblMapNombre = MapInfo.Name
         frmMain.lblMapMusica = MapInfo.Music
@@ -901,7 +947,7 @@ Sub Cargar_CSM(ByVal Map As String)
     On Error GoTo ErrorHandler
 
     Dim fh           As Integer
-    Dim File         As Integer
+    Dim file         As Integer
     Dim MH           As tMapHeader
 
     Dim Blqs()       As tDatosBloqueados
@@ -1111,10 +1157,10 @@ ErrorHandler:
 
     If fh <> 0 Then Close fh
     Call AddtoRichTextBox(frmMain.StatTxt, "Error en el Mapa " & Map & ", se ha generado un informe de errores en: " & App.Path & "\Logs.txt", 255, 0, 0)
-    File = FreeFile
-    Open App.Path & "\Logs.txt" For Output As #File
-    Print #File, Err.Description
-    Close #File
+    file = FreeFile
+    Open App.Path & "\Logs.txt" For Output As #file
+    Print #file, Err.Description
+    Close #file
 
 End Sub
 
@@ -1316,215 +1362,6 @@ ErrorHandler:
     If fh <> 0 Then Close fh
 
 End Function
-
-Public Sub MapaInteger_Cargar(ByVal Map As String)
-    '*************************************************
-    'Author: ^[GS]^
-    'Last modified: 20/05/06
-    '*************************************************
-
-    On Error Resume Next
-
-    Dim loopC       As Integer
-    Dim TempInt     As Integer
-    Dim Body        As Integer
-    Dim Head        As Integer
-    Dim Heading     As Byte
-    Dim Y           As Integer
-    Dim X           As Integer
-    Dim ByFlags     As Byte
-    Dim FreeFileMap As Long
-    Dim FreeFileInf As Long
-
-    DoEvents
-    
-    'Change mouse icon
-    frmMain.MousePointer = 11
-       
-    'Open files
-    FreeFileMap = FreeFile
-    Open Map For Binary As FreeFileMap
-    Seek FreeFileMap, 1
-    
-    Map = Left(Map, Len(Map) - 4)
-    Map = Map & ".inf"
-    
-    FreeFileInf = FreeFile
-    Open Map For Binary As FreeFileInf
-    Seek FreeFileInf, 1
-    
-    'Cabecera map
-    Get FreeFileMap, , MapInfo.MapVersion
-    Get FreeFileMap, , MiCabecera
-    Get FreeFileMap, , TempInt
-    Get FreeFileMap, , TempInt
-    Get FreeFileMap, , TempInt
-    Get FreeFileMap, , TempInt
-    
-    'Cabecera inf
-    Get FreeFileInf, , TempInt
-    Get FreeFileInf, , TempInt
-    Get FreeFileInf, , TempInt
-    Get FreeFileInf, , TempInt
-    Get FreeFileInf, , TempInt
-            
-    Particle_Group_Remove_All
-    
-    'Load arrays
-    For Y = YMinMapSize To YMaxMapSize
-        For X = XMinMapSize To XMaxMapSize
-            
-            With MapData(X, Y)
-            
-                Dim i As Byte
-                For i = 0 To 3
-
-                    If .light_value(i) = True Then
-                        .light_value(i) = False
-                    End If
-
-                Next i
-    
-                Get FreeFileMap, , ByFlags
-                .blocked = (ByFlags And 1)
-                
-                'Layer 1
-                Get FreeFileMap, , .Graphic(1).GrhIndexIntg
-                Call InitGrh(.Graphic(1), .Graphic(1).GrhIndexIntg)
-            
-                'Layer 2 used?
-                If ByFlags And 2 Then
-                    Get FreeFileMap, , .Graphic(2).GrhIndexIntg
-                    Call InitGrh(.Graphic(2), .Graphic(2).GrhIndexIntg)
-                Else
-                    .Graphic(2).GrhIndexIntg = 0
-                End If
-                
-                'Layer 3 used?
-                If ByFlags And 4 Then
-                    Get FreeFileMap, , .Graphic(3).GrhIndexIntg
-                    Call InitGrh(.Graphic(3), .Graphic(3).GrhIndexIntg)
-                Else
-                    .Graphic(3).GrhIndexIntg = 0
-                End If
-                
-                'Layer 4 used?
-                If ByFlags And 8 Then
-                    Get FreeFileMap, , .Graphic(4).GrhIndexIntg
-                    Call InitGrh(.Graphic(4), .Graphic(4).GrhIndexIntg)
-                Else
-                    .Graphic(4).GrhIndexIntg = 0
-                End If
-             
-                'Trigger used?
-                If ByFlags And 16 Then
-                    Get FreeFileMap, , .Trigger
-                Else
-                    .Trigger = 0
-                End If
-            
-                'Particles used?
-                If ByFlags And 32 Then
-                    Get FreeFileMap, , TempInt
-                    .particle_group_index = General_Particle_Create(TempInt, X, Y, -1)
-                End If
-            
-                If ByFlags And 64 Then
-                    'Get FreeFileMap, , .base_light(0)
-                    'Get FreeFileMap, , .base_light(1)
-                    'Get FreeFileMap, , .base_light(2)
-                    'Get FreeFileMap, , .base_light(3)
-                    '
-                    'If .base_light(0) Then _
-                    '    Get FreeFileMap, , .light_value(0)
-                    '
-                    'If .base_light(1) Then _
-                    '    Get FreeFileMap, , .light_value(1)
-                    '
-                    'If .base_light(2) Then _
-                    '    Get FreeFileMap, , .light_value(2)
-                    '
-                    'If .base_light(3) Then _
-                    '    Get FreeFileMap, , .light_value(3)
-                End If
-            
-                'Leemos el archivo ".INF"
-                Get FreeFileInf, , ByFlags
-            
-                If ByFlags And 1 Then
-                
-                    With .TileExit
-                    
-                        Get FreeFileInf, , .Map
-                        Get FreeFileInf, , .X
-                        Get FreeFileInf, , .Y
-                    
-                    End With
-
-                End If
-    
-                If ByFlags And 2 Then
-                
-                    'Get and make NPC
-                    Get FreeFileInf, , .NPCIndex
-    
-                    If .NPCIndex < 0 Then
-                    
-                        .NPCIndex = 0
-                        
-                    Else
-                    
-                        Body = NpcData(.NPCIndex).Body
-                        Head = NpcData(.NPCIndex).Head
-                        Heading = NpcData(.NPCIndex).Heading
-                        Call MakeChar(NextOpenChar(), Body, Head, Heading, X, Y)
-
-                    End If
-
-                End If
-    
-                If ByFlags And 4 Then
-        
-                    'Get and make Object
-                    Get FreeFileInf, , .OBJInfo.objindex
-                    Get FreeFileInf, , .OBJInfo.Amount
-    
-                    If .OBJInfo.objindex > 0 Then
-                        Call InitGrh(.ObjGrh, ObjData(.OBJInfo.objindex).GrhIndex)
-                    End If
-
-                End If
-            
-            End With
-    
-        Next X
-    Next Y
-    
-    'Close files
-    Close FreeFileMap
-    Close FreeFileInf
-    
-    Call Pestañas(Map, ".map")
-
-    Call DibujarMiniMapa ' Radar
-    
-    Map = Left$(Map, Len(Map) - 4) & ".dat"
-    
-    MapInfo_Cargar Map
-    frmMain.lblMapVersion.Caption = MapInfo.MapVersion
-    
-    'Set changed flag
-    MapInfo.Changed = 0
-    
-    ' Vacia el Deshacer
-    modEdicion.Deshacer_Clear
-    
-    'Change mouse icon
-    frmMain.MousePointer = 0
-    
-    MapaCargado = True
-    
-End Sub
 
 Public Sub CSMInfoSave()
 

--- a/Codigo/modMapIO.bas
+++ b/Codigo/modMapIO.bas
@@ -434,18 +434,31 @@ Public Sub MapaV2_Guardar(ByVal SaveAs As String, Optional ByVal Preguntar As Bo
                 ByFlags = 0
                 
                 If .blocked = 1 Then ByFlags = ByFlags Or 1
+                
                 If .Graphic(2).GrhIndex Then ByFlags = ByFlags Or 2
                 If .Graphic(3).GrhIndex Then ByFlags = ByFlags Or 4
                 If .Graphic(4).GrhIndex Then ByFlags = ByFlags Or 8
+
                 If .Trigger Then ByFlags = ByFlags Or 16
+                
                 If .particle_group_index Then ByFlags = ByFlags Or 32
                     
                 Put FreeFileMap, , ByFlags
                     
-                Put FreeFileMap, , .Graphic(1).GrhIndex
-                    
+                If MapaCargado_Integer Then
+                    Put FreeFileMap, , .Graphic(1).GrhIndexIntg
+                Else
+                    Put FreeFileMap, , .Graphic(1).GrhIndex
+                End If
+                
                 For loopC = 2 To 4
-                    If .Graphic(loopC).GrhIndex Then Put FreeFileMap, , .Graphic(loopC).GrhIndex
+                    
+                    If MapaCargado_Integer Then
+                        If .Graphic(loopC).GrhIndex Then Put FreeFileMap, , .Graphic(loopC).GrhIndexIntg
+                    Else
+                        If .Graphic(loopC).GrhIndex Then Put FreeFileMap, , .Graphic(loopC).GrhIndex
+                    End If
+
                 Next loopC
                     
                 If .Trigger Then Put FreeFileMap, , .Trigger


### PR DESCRIPTION
- MapaInteger_Cargar y MapaV2_Cargar fueron unificados.
- Nueva variable publica que le dice al WE si estas trabajando con mapas Integer o Long.
- Arreglado WE se crashea al cargar mapas Integer desde las Pestañas.
- Si abriste el mapa como integer, lo guardamos como Integer.
(A menos que estemos convirtiendolos, en ese caso seteamos `MapaCargado_Integer = False` para obligar a MapaV2_Guardar que lo guarde como Long)